### PR TITLE
Fix ThemeProvider hydration error by always providing context

### DIFF
--- a/src/lib/theme-context.tsx
+++ b/src/lib/theme-context.tsx
@@ -66,11 +66,7 @@ export function ThemeProvider({ children }: { children: ReactNode }) {
     setTheme,
   };
 
-  // Prevent hydration mismatch by not rendering theme-dependent content until mounted
-  if (!mounted) {
-    return <React.Fragment>{children}</React.Fragment>;
-  }
-
+  // Always provide the context, even when not mounted
   return (
     <ThemeContext.Provider value={contextValue}>
       {children}


### PR DESCRIPTION
Modified ThemeProvider to always wrap children with ThemeContext.Provider even when not mounted, preventing "useTheme must be used within a ThemeProvider" errors during hydration. This ensures the context is available throughout the component lifecycle while maintaining theme functionality.

🤖 Generated with [Claude Code](https://claude.ai/code)